### PR TITLE
fix c4-6

### DIFF
--- a/src/pendle-rewards/RewardManager.sol
+++ b/src/pendle-rewards/RewardManager.sol
@@ -63,6 +63,7 @@ contract RewardManager is RewardManagerAbstract {
             for (uint256 i = 0; i < tokens.length; ++i) {
                 address token = tokens[i];
 
+                if (token == address(market)) continue;
                 // the entire token balance of the contract must be the rewards of the contract
 
                 RewardState memory _state = rewardState[token];


### PR DESCRIPTION
This fix is probably not needed bc the reward manager can't handle rewards in the same pendle market token (i.e. rewarding LP token for the same LP token market), but can add a safety measure in case Pendle acts as malicious actor via permissioned functions and adds it in their reward tokens. 